### PR TITLE
fix: Bluesky getPosts クエリパラメータを uris[] から uris に修正

### DIFF
--- a/src/blueskyClient.js
+++ b/src/blueskyClient.js
@@ -110,7 +110,7 @@ export async function fetchBlueskyPosts({ handle, since }) {
 }
 
 export async function fetchBlueskyPostByUri(uri) {
-  const url = `${BLUESKY_API_ENDPOINT}/app.bsky.feed.getPosts?uris[]=${encodeURIComponent(uri)}`;
+  const url = `${BLUESKY_API_ENDPOINT}/app.bsky.feed.getPosts?uris=${encodeURIComponent(uri)}`;
   const res = await fetch(url);
   if (!res.ok) {
     const body = await res.text().catch(() => '');


### PR DESCRIPTION
## 概要
`app.bsky.feed.getPosts` API のクエリパラメータが `uris[]` になっていたため、Bluesky API から 400 Bad Request が返されていた。

## 原因
PHP スタイルの配列パラメータ `uris[]=...` を使用していたが、Bluesky API は `uris=...` を要求している。

## 変更内容
- `src/blueskyClient.js`: `uris[]` → `uris` に修正